### PR TITLE
change MarkWord Project Rreference dll to Solution directory/DLL

### DIFF
--- a/MarkWord/MarkWord.csproj
+++ b/MarkWord/MarkWord.csproj
@@ -43,7 +43,7 @@
     </Reference>
     <Reference Include="CommonMark, Version=0.1.0.0, Culture=neutral, PublicKeyToken=001ef8810438905d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\CommonMark.NET-master\CommonMark\bin\v4.0\Release\CommonMark.dll</HintPath>
+      <HintPath>..\DLL\CommonMark.dll</HintPath>
     </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -51,17 +51,17 @@
     </Reference>
     <Reference Include="Fluent, Version=4.0.3.0, Culture=neutral, PublicKeyToken=3e436e32a8c5546f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\Fluent.Ribbon\Fluent.Ribbon-master\build\bin\NET 4.0\Release\Fluent.dll</HintPath>
+      <HintPath>..\DLL\Fluent.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack">
-      <HintPath>..\..\..\..\源程序\HtmlAgilityPack.1.4.6\Net40\HtmlAgilityPack.dll</HintPath>
+      <HintPath>..\DLL\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.AvalonEdit">
-      <HintPath>..\..\..\..\AvalonEdit-master\ICSharpCode.AvalonEdit\bin\Release\ICSharpCode.AvalonEdit.dll</HintPath>
+      <HintPath>..\DLL\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
     <Reference Include="Pechkin, Version=0.5.8.1, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>bin\Debug\Pechkin.dll</HintPath>
+      <HintPath>..\DLL\Pechkin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
将MarkWord的项目引用更新为引用解决方案下的DLL目录内的DLL，以便其他人下载后可以直接运行
